### PR TITLE
Some cleanup.

### DIFF
--- a/maple-core/src/main/java/io/soabase/maple/api/Statement.java
+++ b/maple-core/src/main/java/io/soabase/maple/api/Statement.java
@@ -31,12 +31,12 @@ public interface Statement<T> {
      *
      * <pre>
      * // partialLog is "pre filled" with fields/values
-     * Statement<LoggingSchema> partialLog = s -> s.event(UPDATE).customerId(customerId);
+     * Statement&lt;LoggingSchema&gt; partialLog = s -&gt; s.event(UPDATE).customerId(customerId);
      *
      * ... later ...
      *
      * // partialLog is used along with the additional field "eventDetail"
-     * logger.info(partialLog.concat(s -> s.eventDetail("success"));
+     * logger.info(partialLog.concat(s -&gt; s.eventDetail("success"));
      * </pre>
      *
      * @param partialStatement - statement to concat

--- a/maple-core/src/main/java/io/soabase/maple/core/Instance.java
+++ b/maple-core/src/main/java/io/soabase/maple/core/Instance.java
@@ -23,8 +23,4 @@ public class Instance {
     public void internalSetValueAtIndex(int index, Object value) {
         arguments[index] = value;
     }
-
-    public void internalFormattedAtIndex(int index, String format, Object[] args) {
-        internalSetValueAtIndex(index, String.format(format, args));
-    }
 }


### PR DESCRIPTION
Some cleanup. 1) Instance.java had an old method that isn't used anymore. 2) generator can re-use generated classes - they don't need to be unique for each formatter. 3) Added some tests to ensure generator caching is working correctly.