### PR TITLE
Change `@DoNotLog` to use Jackson "annotation bundle" with `@JsonIgnore`

### DIFF
--- a/maple-core/src/main/java/io/soabase/maple/api/annotations/DoNotLog.java
+++ b/maple-core/src/main/java/io/soabase/maple/api/annotations/DoNotLog.java
@@ -15,7 +15,8 @@
  */
 package io.soabase.maple.api.annotations;
 
-import com.fasterxml.jackson.annotation.JacksonAnnotation;
+import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -31,6 +32,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD})
-@JacksonAnnotation
+@JacksonAnnotationsInside
+@JsonIgnore
 public @interface DoNotLog {
 }

--- a/maple-core/src/test/java/io/soabase/maple/TestFormatters.java
+++ b/maple-core/src/test/java/io/soabase/maple/TestFormatters.java
@@ -122,7 +122,6 @@ class TestFormatters {
     @Test
     void testModelFormatter() {
         ObjectMapper mapper = new ObjectMapper();
-        DoNotLogAnnotationIntrospector.register(mapper);
         MapleSpi.instance().setFormatter(new ModelFormatter(forMapper(mapper), SNAKE_CASE, QUOTE_VALUES_IF_NEEDED, ESCAPE_VALUES));
 
         Address address = new Address("123 Main St", "Newtown", "New Fornia", "12225", "do not show");


### PR DESCRIPTION
So, had a quick look and noticed that for intended use, code can use Jackson's "Annotation bundle" feature: if there is marker `@JacksonAnnotationsInside` then check is made for other included (meta-annotations). The main benefit here is that I think it removes the need for `DoNotLogAnnotationIntrospector`, at least for now.
