### PR TITLE
Example of how to do MDC in Maple and additional MDC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,43 @@ public interface Logging {
 
 ```
 
+### MDC
+
+You can set [MDC](http://www.slf4j.org/api/org/slf4j/MDC.html) values using structured schema. E.g.
+
+```
+...
+MapleLogger<Schema> log = ...
+
+...
+
+try (log.mdc(s -> s.transactionId(id).code(c))) {
+    // do work - MDC values are removed afterwards
+}
+```
+
+_Using MDC as default values_
+
+You can annotate schema methods with `@MdcDefaultValue`. For these methods if you do not specify
+a value directly, Maple will look in the MDC for the value. E.g.
+
+```
+public interface Schema {
+    ...
+    Schema name(String name);
+
+    @MdcDefaultValue
+    Schema transactionId(String id);
+    ...
+}
+
+try (log.mdc(s -> s.transactionId(id))) {
+    
+    log.info(s -> s.name(n));   // transactionId is also logged here
+}
+
+``` 
+
 ### Unstructured Logging, Exceptions
 
 You can include an unstructured message as well as any exceptions in your log statements. E.g.

--- a/maple-core/src/main/java/io/soabase/maple/api/MapleLoggerApi.java
+++ b/maple-core/src/main/java/io/soabase/maple/api/MapleLoggerApi.java
@@ -215,4 +215,12 @@ public interface MapleLoggerApi<T> {
      * @param statement structured logging statement
      */
     void error(String mainMessage, Throwable t, Statement<T> statement);
+
+    /**
+     * Pass the generated name/values to the logger's MDC system
+     *
+     * @param statement structured logging statement
+     * @return a closeable - when closed the schema names are removed from MDC
+     */
+    MdcCloseable mdc(Statement<T> statement);
 }

--- a/maple-core/src/main/java/io/soabase/maple/api/MdcCloseable.java
+++ b/maple-core/src/main/java/io/soabase/maple/api/MdcCloseable.java
@@ -13,14 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.soabase.maple.slf4j;
+package io.soabase.maple.api;
 
-import io.soabase.maple.core.StandardMapleLogger;
-import io.soabase.maple.spi.MetaInstance;
-import org.slf4j.Logger;
-
-class MapleLoggerImpl<T> extends StandardMapleLogger<T, Logger> implements MapleLogger<T> {
-    MapleLoggerImpl(MetaInstance<T> metaInstance, Logger logger) {
-        super(metaInstance, logger, Utils::isEnabled, Utils::levelLogger);
-    }
+public interface MdcCloseable extends AutoCloseable {
+    void close();
 }

--- a/maple-core/src/main/java/io/soabase/maple/api/Names.java
+++ b/maple-core/src/main/java/io/soabase/maple/api/Names.java
@@ -15,10 +15,12 @@
  */
 package io.soabase.maple.api;
 
+import java.util.Set;
+
 public interface Names {
     int qty();
 
     String nthName(int n);
 
-    boolean nthIsRequired(int n);
+    Set<Specialization> nthSpecializations(int n);
 }

--- a/maple-core/src/main/java/io/soabase/maple/api/Specialization.java
+++ b/maple-core/src/main/java/io/soabase/maple/api/Specialization.java
@@ -13,14 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.soabase.maple.slf4j;
+package io.soabase.maple.api;
 
-import io.soabase.maple.core.StandardMapleLogger;
-import io.soabase.maple.spi.MetaInstance;
-import org.slf4j.Logger;
-
-class MapleLoggerImpl<T> extends StandardMapleLogger<T, Logger> implements MapleLogger<T> {
-    MapleLoggerImpl(MetaInstance<T> metaInstance, Logger logger) {
-        super(metaInstance, logger, Utils::isEnabled, Utils::levelLogger);
-    }
+public enum Specialization {
+    REQUIRED,
+    DEFAULT_FROM_MDC
 }

--- a/maple-core/src/main/java/io/soabase/maple/api/annotations/MdcDefaultValue.java
+++ b/maple-core/src/main/java/io/soabase/maple/api/annotations/MdcDefaultValue.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.maple.api.annotations;
+
+import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Can be used with {@link io.soabase.maple.api.MapleFormatter}s that use Jackson
+ * (e.g. {@link io.soabase.maple.formatters.ModelFormatter}. Fields annotated with this
+ * will not get logged. For example, mark password fields or any other security sensitive fields.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD})
+@JacksonAnnotationsInside
+@JsonIgnore
+public @interface MdcDefaultValue {
+}

--- a/maple-core/src/main/java/io/soabase/maple/core/SpecializedNamesValues.java
+++ b/maple-core/src/main/java/io/soabase/maple/core/SpecializedNamesValues.java
@@ -20,20 +20,19 @@ import io.soabase.maple.api.Names;
 import io.soabase.maple.api.NamesValues;
 import io.soabase.maple.api.Specialization;
 
-import java.util.Iterator;
 import java.util.Set;
-import java.util.Spliterator;
-import java.util.Spliterators;
+import java.util.function.IntFunction;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
-class NamesValuesImp implements NamesValues {
+import static io.soabase.maple.core.NamesValuesImp.newStream;
+
+public class SpecializedNamesValues implements NamesValues {
     private final Names names;
-    private final Object[] arguments;
+    private final IntFunction<Object> valueProc;
 
-    NamesValuesImp(Names names, Object[] arguments) {
+    public SpecializedNamesValues(Names names, IntFunction<Object> valueProc) {
         this.names = names;
-        this.arguments = arguments;
+        this.valueProc = valueProc;
     }
 
     @Override
@@ -48,7 +47,7 @@ class NamesValuesImp implements NamesValues {
 
     @Override
     public Object nthValue(int n) {
-        return arguments[n];
+        return valueProc.apply(n);
     }
 
     @Override
@@ -59,33 +58,5 @@ class NamesValuesImp implements NamesValues {
     @Override
     public Stream<NameValue> stream() {
         return newStream(this);
-    }
-
-    static Stream<NameValue> newStream(NamesValues namesValues) {
-        Iterator<NameValue> iterator = new Iterator<NameValue>() {
-            private int index = -1;
-
-            @Override
-            public boolean hasNext() {
-                return (index + 1) < namesValues.qty();
-            }
-
-            @Override
-            public NameValue next() {
-                int thisIndex = ++index;
-                return new NameValue() {
-                    @Override
-                    public String name() {
-                        return namesValues.nthName(thisIndex);
-                    }
-
-                    @Override
-                    public Object value() {
-                        return namesValues.nthValue(thisIndex);
-                    }
-                };
-            }
-        };
-        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false);
     }
 }

--- a/maple-core/src/main/java/io/soabase/maple/core/StandardMapleLogger.java
+++ b/maple-core/src/main/java/io/soabase/maple/core/StandardMapleLogger.java
@@ -15,9 +15,7 @@
  */
 package io.soabase.maple.core;
 
-import io.soabase.maple.api.LevelLogger;
-import io.soabase.maple.api.LoggingLevel;
-import io.soabase.maple.api.Statement;
+import io.soabase.maple.api.*;
 import io.soabase.maple.spi.MapleSpi;
 import io.soabase.maple.spi.MetaInstance;
 
@@ -49,6 +47,13 @@ public class StandardMapleLogger<T, LOGGER> implements MapleLoggerBase<T> {
         if (isEnabledProc.test(loggingLevel, logger)) {
             MapleSpi.instance().consume(levelLoggerProc.apply(loggingLevel, logger), mainMessage, t, statement, metaInstance);
         }
+    }
+
+    @Override
+    public MdcCloseable mdc(Statement<T> statement) {
+        NamesValues namesValues = statement.toNamesValues(getMetaInstance());
+        namesValues.stream().forEach(nameValue -> MapleSpi.instance().putMdcValue(nameValue.name(), String.valueOf(nameValue.value())));
+        return () -> namesValues.stream().forEach(nameValue -> MapleSpi.instance().removeMdcValue(nameValue.name()));
     }
 
     public MetaInstance<T> getMetaInstance() {

--- a/maple-core/src/main/java/io/soabase/maple/formatters/ModelFormatter.java
+++ b/maple-core/src/main/java/io/soabase/maple/formatters/ModelFormatter.java
@@ -18,10 +18,7 @@ package io.soabase.maple.formatters;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.*;
-import io.soabase.maple.api.LevelLogger;
-import io.soabase.maple.api.MapleFormatter;
-import io.soabase.maple.api.NameValue;
-import io.soabase.maple.api.NamesValues;
+import io.soabase.maple.api.*;
 
 import java.util.*;
 import java.util.stream.Stream;
@@ -138,8 +135,8 @@ public class ModelFormatter implements MapleFormatter {
             }
 
             @Override
-            public boolean nthIsRequired(int n) {
-                return false;
+            public Set<Specialization> nthSpecializations(int n) {
+                return Collections.emptySet();
             }
 
             @Override

--- a/maple-core/src/main/java/io/soabase/maple/spi/MapleSpi.java
+++ b/maple-core/src/main/java/io/soabase/maple/spi/MapleSpi.java
@@ -37,9 +37,21 @@ public interface MapleSpi {
 
     MapleFormatter getFormatter();
 
-    void validateRequired(NamesValues namesValues);
+    NamesValues applySpecializations(NamesValues namesValues);
 
     default void reset() {
         setFormatter(null);
+    }
+
+    default Object getMdcValue(String name) {
+        return null;
+    }
+
+    default void putMdcValue(String name, Object value) {
+        // NOP
+    }
+
+    default void removeMdcValue(String name) {
+        // NOP
     }
 }

--- a/maple-core/src/test/java/io/soabase/maple/TestGeneration.java
+++ b/maple-core/src/test/java/io/soabase/maple/TestGeneration.java
@@ -15,18 +15,12 @@
  */
 package io.soabase.maple;
 
-import io.soabase.maple.api.MapleFormatter;
-import io.soabase.maple.api.Names;
-import io.soabase.maple.api.NamesValues;
-import io.soabase.maple.api.Statement;
+import io.soabase.maple.api.*;
 import io.soabase.maple.api.exceptions.InvalidSchemaException;
 import io.soabase.maple.api.exceptions.MissingSchemaValueException;
 import io.soabase.maple.core.Generator;
 import io.soabase.maple.formatters.StandardFormatter;
-import io.soabase.maple.schema.BasicSchema;
-import io.soabase.maple.schema.HasRequired;
-import io.soabase.maple.schema.HasSortOrder;
-import io.soabase.maple.schema.MultiMethodDefaults;
+import io.soabase.maple.schema.*;
 import io.soabase.maple.schema.invalid.*;
 import io.soabase.maple.spi.MapleSpi;
 import io.soabase.maple.spi.MetaInstance;
@@ -94,7 +88,7 @@ class TestGeneration {
     @Test
     void testRequired() {
         Names names = buildNames(HasRequired.class);
-        assertThat(names.nthIsRequired(1)).isTrue();
+        assertThat(names.nthSpecializations(1).contains(Specialization.REQUIRED)).isTrue();
 
         MetaInstance<HasRequired> metaInstance = generate(names, HasRequired.class);
         HasRequired instance = metaInstance.newSchemaInstance();
@@ -104,10 +98,16 @@ class TestGeneration {
         try {
             MapleSpi.instance().setProductionMode(false);
             NamesValues namesValues = metaInstance.toNamesValues(instance);
-            assertThatThrownBy(() -> MapleSpi.instance().validateRequired(namesValues)).isInstanceOf(MissingSchemaValueException.class);
+            assertThatThrownBy(() -> MapleSpi.instance().applySpecializations(namesValues)).isInstanceOf(MissingSchemaValueException.class);
         } catch (Exception e) {
             MapleSpi.instance().setProductionMode(saveProductionMode);
         }
+    }
+
+    @Test
+    void testMdcDefaultValue() {
+        Names names = buildNames(HasMdcDefault.class);
+        assertThat(names.nthSpecializations(0).contains(Specialization.DEFAULT_FROM_MDC)).isTrue();
     }
 
     @Test

--- a/maple-core/src/test/java/io/soabase/maple/schema/HasMdcDefault.java
+++ b/maple-core/src/test/java/io/soabase/maple/schema/HasMdcDefault.java
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.soabase.maple.slf4j;
+package io.soabase.maple.schema;
 
-import io.soabase.maple.core.StandardMapleLogger;
-import io.soabase.maple.spi.MetaInstance;
-import org.slf4j.Logger;
+import io.soabase.maple.api.annotations.MdcDefaultValue;
 
-class MapleLoggerImpl<T> extends StandardMapleLogger<T, Logger> implements MapleLogger<T> {
-    MapleLoggerImpl(MetaInstance<T> metaInstance, Logger logger) {
-        super(metaInstance, logger, Utils::isEnabled, Utils::levelLogger);
-    }
+public interface HasMdcDefault {
+    @MdcDefaultValue
+    HasMdcDefault mdcValue(int i);
+
+    HasMdcDefault name(String name);
 }

--- a/maple-examples/README.md
+++ b/maple-examples/README.md
@@ -11,3 +11,4 @@ See:
 - [RequestHandler.java](src/main/java/com/myco/app/request/RequestHandler.java) - structured logging example
 - [UpdateService.java](src/main/java/com/myco/app/request/UpdateService.java) - structured logging example with composed logging. Also 
 has an example of using [@DoNotLog](src/main/java/com/myco/app/request/PayloadModel.java) to prevent sensitive data from being logged.
+- [RestEndpoint.java](src/main/java/com/myco/app/mdc/RestEndpoint.java) - example of using structured MDC 

--- a/maple-examples/src/main/java/com/myco/app/mdc/MdcSchema.java
+++ b/maple-examples/src/main/java/com/myco/app/mdc/MdcSchema.java
@@ -13,14 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.soabase.maple.slf4j;
+package com.myco.app.mdc;
 
-import io.soabase.maple.core.StandardMapleLogger;
-import io.soabase.maple.spi.MetaInstance;
-import org.slf4j.Logger;
+public interface MdcSchema {
+    MdcSchema transactionId(String id);
 
-class MapleLoggerImpl<T> extends StandardMapleLogger<T, Logger> implements MapleLogger<T> {
-    MapleLoggerImpl(MetaInstance<T> metaInstance, Logger logger) {
-        super(metaInstance, logger, Utils::isEnabled, Utils::levelLogger);
-    }
+    MdcSchema transactionOwner(String owner);
 }

--- a/maple-examples/src/main/java/com/myco/app/mdc/Request.java
+++ b/maple-examples/src/main/java/com/myco/app/mdc/Request.java
@@ -13,14 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.soabase.maple.slf4j;
+package com.myco.app.mdc;
 
-import io.soabase.maple.core.StandardMapleLogger;
-import io.soabase.maple.spi.MetaInstance;
-import org.slf4j.Logger;
+import java.util.UUID;
 
-class MapleLoggerImpl<T> extends StandardMapleLogger<T, Logger> implements MapleLogger<T> {
-    MapleLoggerImpl(MetaInstance<T> metaInstance, Logger logger) {
-        super(metaInstance, logger, Utils::isEnabled, Utils::levelLogger);
+public class Request {
+    private final TransactionMetaData metaData;
+    private final String name;
+    private final UUID id;
+
+    public Request(TransactionMetaData metaData, String name, UUID id) {
+        this.metaData = metaData;
+        this.name = name;
+        this.id = id;
+    }
+
+    public TransactionMetaData getMetaData() {
+        return metaData;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public UUID getId() {
+        return id;
     }
 }

--- a/maple-examples/src/main/java/com/myco/app/mdc/RequestHandler.java
+++ b/maple-examples/src/main/java/com/myco/app/mdc/RequestHandler.java
@@ -13,14 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.soabase.maple.slf4j;
+package com.myco.app.mdc;
 
-import io.soabase.maple.core.StandardMapleLogger;
-import io.soabase.maple.spi.MetaInstance;
-import org.slf4j.Logger;
+import com.myco.app.logging.Logging;
+import com.myco.app.logging.LoggingEventType;
+import com.myco.app.logging.LoggingSchema;
+import io.soabase.maple.slf4j.MapleLogger;
 
-class MapleLoggerImpl<T> extends StandardMapleLogger<T, Logger> implements MapleLogger<T> {
-    MapleLoggerImpl(MetaInstance<T> metaInstance, Logger logger) {
-        super(metaInstance, logger, Utils::isEnabled, Utils::levelLogger);
+public class RequestHandler {
+    private final MapleLogger<LoggingSchema> log = Logging.get(getClass());
+
+    public void handleRequest(Request request) {
+        // normal logging. The underlying logging framework will add the MDC values
+        log.info(s -> s.event(LoggingEventType.USER_REQUEST).eventDetail(request.getName()).customerId(request.getId()));
+
+        // etc.
     }
 }

--- a/maple-examples/src/main/java/com/myco/app/mdc/RestEndpoint.java
+++ b/maple-examples/src/main/java/com/myco/app/mdc/RestEndpoint.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.myco.app.mdc;
+
+import io.soabase.maple.api.MdcCloseable;
+import io.soabase.maple.slf4j.MapleFactory;
+import io.soabase.maple.slf4j.MapleLogger;
+
+public class RestEndpoint {
+    // uses a specialized logging schema solely for MDC
+    private final MapleLogger<MdcSchema> log = MapleFactory.getLogger(getClass(), MdcSchema.class);
+
+    public void putRequest(Request request) {
+        // sets the MDC context for the request (automatically clearing using try-with-resources)
+        // given MdcSchema, the MDC fields are "transactionId" and "transactionOwner"
+        // see logback.xml for the logging spec
+        try (MdcCloseable mdc = log.mdc(s -> s.transactionId(request.getMetaData().getId()).transactionOwner(request.getMetaData().getOwner())) ) {
+            new RequestHandler().handleRequest(request);
+        }
+    }
+}

--- a/maple-examples/src/main/java/com/myco/app/mdc/TransactionMetaData.java
+++ b/maple-examples/src/main/java/com/myco/app/mdc/TransactionMetaData.java
@@ -13,14 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.soabase.maple.slf4j;
+package com.myco.app.mdc;
 
-import io.soabase.maple.core.StandardMapleLogger;
-import io.soabase.maple.spi.MetaInstance;
-import org.slf4j.Logger;
+public class TransactionMetaData {
+    private final String id;
+    private final String owner;
 
-class MapleLoggerImpl<T> extends StandardMapleLogger<T, Logger> implements MapleLogger<T> {
-    MapleLoggerImpl(MetaInstance<T> metaInstance, Logger logger) {
-        super(metaInstance, logger, Utils::isEnabled, Utils::levelLogger);
+    public TransactionMetaData(String id, String owner) {
+        this.id = id;
+        this.owner = owner;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getOwner() {
+        return owner;
     }
 }

--- a/maple-examples/src/main/resources/logback.xml
+++ b/maple-examples/src/main/resources/logback.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2019 Jordan Zimmerman
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%-5level] %logger{15} - %msg%n%rEx - tx.id=%X{transactionId} tx.owner=%X{transactionOwner}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="CONSOLE" />
+    </root>
+</configuration>

--- a/maple-slf4j/src/main/java/io/soabase/maple/slf4j/MapleLogger.java
+++ b/maple-slf4j/src/main/java/io/soabase/maple/slf4j/MapleLogger.java
@@ -16,7 +16,6 @@
 package io.soabase.maple.slf4j;
 
 import io.soabase.maple.api.MapleLoggerApi;
-import io.soabase.maple.api.Statement;
 import org.slf4j.Logger;
 
 public interface MapleLogger<T> extends MapleLoggerApi<T> {
@@ -26,16 +25,4 @@ public interface MapleLogger<T> extends MapleLoggerApi<T> {
      * @return SLF4J logger
      */
     Logger logger();
-
-    interface MdcCloseable extends AutoCloseable {
-        void close();
-    }
-
-    /**
-     * Pass the generated name/values to the SLF4J's {@link org.slf4j.MDC#put(String, String)}
-     *
-     * @param statement structured logging statement
-     * @return a closeable - when closed the schema names are removed from MDC
-     */
-    MdcCloseable mdc(Statement<T> statement);
 }

--- a/maple-slf4j/src/main/java/io/soabase/maple/slf4j/MapleSlf4jSpi.java
+++ b/maple-slf4j/src/main/java/io/soabase/maple/slf4j/MapleSlf4jSpi.java
@@ -15,12 +15,22 @@
  */
 package io.soabase.maple.slf4j;
 
-import io.soabase.maple.core.StandardMapleLogger;
-import io.soabase.maple.spi.MetaInstance;
-import org.slf4j.Logger;
+import io.soabase.maple.spi.StandardMapleSpi;
+import org.slf4j.MDC;
 
-class MapleLoggerImpl<T> extends StandardMapleLogger<T, Logger> implements MapleLogger<T> {
-    MapleLoggerImpl(MetaInstance<T> metaInstance, Logger logger) {
-        super(metaInstance, logger, Utils::isEnabled, Utils::levelLogger);
+public class MapleSlf4jSpi extends StandardMapleSpi {
+    @Override
+    public Object getMdcValue(String name) {
+        return MDC.get(name);
+    }
+
+    @Override
+    public void putMdcValue(String name, Object value) {
+        MDC.put(name, String.valueOf(value));
+    }
+
+    @Override
+    public void removeMdcValue(String name) {
+        MDC.remove(name);
     }
 }

--- a/maple-slf4j/src/main/resources/META-INF/services/io.soabase.maple.spi.MapleSpi
+++ b/maple-slf4j/src/main/resources/META-INF/services/io.soabase.maple.spi.MapleSpi
@@ -1,0 +1,1 @@
+io.soabase.maple.slf4j.MapleSlf4jSpi

--- a/maple-slf4j/src/test/java/io/soabase/maple/slf4j/SchemaWithMdc.java
+++ b/maple-slf4j/src/test/java/io/soabase/maple/slf4j/SchemaWithMdc.java
@@ -15,12 +15,13 @@
  */
 package io.soabase.maple.slf4j;
 
-import io.soabase.maple.core.StandardMapleLogger;
-import io.soabase.maple.spi.MetaInstance;
-import org.slf4j.Logger;
+import io.soabase.maple.api.annotations.MdcDefaultValue;
 
-class MapleLoggerImpl<T> extends StandardMapleLogger<T, Logger> implements MapleLogger<T> {
-    MapleLoggerImpl(MetaInstance<T> metaInstance, Logger logger) {
-        super(metaInstance, logger, Utils::isEnabled, Utils::levelLogger);
-    }
+public interface SchemaWithMdc {
+    SchemaWithMdc name(String name);
+
+    SchemaWithMdc age(int age);
+
+    @MdcDefaultValue
+    SchemaWithMdc transactionId(String defaultId);
 }

--- a/maple-slf4j/src/test/java/org/slf4j/impl/StaticMDCBinder.java
+++ b/maple-slf4j/src/test/java/org/slf4j/impl/StaticMDCBinder.java
@@ -13,14 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.soabase.maple.slf4j;
+package org.slf4j.impl;
 
-import io.soabase.maple.core.StandardMapleLogger;
-import io.soabase.maple.spi.MetaInstance;
-import org.slf4j.Logger;
+import org.slf4j.helpers.BasicMDCAdapter;
+import org.slf4j.spi.MDCAdapter;
 
-class MapleLoggerImpl<T> extends StandardMapleLogger<T, Logger> implements MapleLogger<T> {
-    MapleLoggerImpl(MetaInstance<T> metaInstance, Logger logger) {
-        super(metaInstance, logger, Utils::isEnabled, Utils::levelLogger);
+public class StaticMDCBinder {
+    public static final StaticMDCBinder SINGLETON = new StaticMDCBinder();
+
+    private StaticMDCBinder() {
+    }
+
+    public MDCAdapter getMDCA() {
+        return new BasicMDCAdapter();
+    }
+
+    public String getMDCAdapterClassStr() {
+        return BasicMDCAdapter.class.getName();
     }
 }


### PR DESCRIPTION
Closes #6 

Example of MDC in Maple. Look at `RestEndpoint.java` first. Also added a new annotation @MdcDefaultValue that allows using MDC default values. See `testDefaultMdcValue()` in `TestLogging.java` to see an example.