### PR TITLE
Relax restriction that a logging schema must contain unique names.

### DIFF
--- a/maple-core/src/main/java/io/soabase/maple/api/Names.java
+++ b/maple-core/src/main/java/io/soabase/maple/api/Names.java
@@ -22,5 +22,7 @@ public interface Names {
 
     String nthName(int n);
 
+    String nthRawName(int n);
+
     Set<Specialization> nthSpecializations(int n);
 }

--- a/maple-core/src/main/java/io/soabase/maple/core/NamesValuesImp.java
+++ b/maple-core/src/main/java/io/soabase/maple/core/NamesValuesImp.java
@@ -47,6 +47,11 @@ class NamesValuesImp implements NamesValues {
     }
 
     @Override
+    public String nthRawName(int n) {
+        return names.nthRawName(n);
+    }
+
+    @Override
     public Object nthValue(int n) {
         return arguments[n];
     }

--- a/maple-core/src/main/java/io/soabase/maple/core/SpecializedNamesValues.java
+++ b/maple-core/src/main/java/io/soabase/maple/core/SpecializedNamesValues.java
@@ -46,6 +46,11 @@ public class SpecializedNamesValues implements NamesValues {
     }
 
     @Override
+    public String nthRawName(int n) {
+        return names.nthRawName(n);
+    }
+
+    @Override
     public Object nthValue(int n) {
         return valueProc.apply(n);
     }

--- a/maple-core/src/main/java/io/soabase/maple/formatters/ModelFormatter.java
+++ b/maple-core/src/main/java/io/soabase/maple/formatters/ModelFormatter.java
@@ -135,6 +135,11 @@ public class ModelFormatter implements MapleFormatter {
             }
 
             @Override
+            public String nthRawName(int n) {
+                return nthName(n);
+            }
+
+            @Override
             public Set<Specialization> nthSpecializations(int n) {
                 return Collections.emptySet();
             }

--- a/maple-core/src/main/java/io/soabase/maple/formatters/StandardFormatter.java
+++ b/maple-core/src/main/java/io/soabase/maple/formatters/StandardFormatter.java
@@ -85,13 +85,15 @@ public class StandardFormatter implements MapleFormatter {
             }
         }
 
-        for (int i = 0; i < namesValues.qty(); ++i, needsSpace = true) {
+        for (int i = 0; i < namesValues.qty(); ++i) {
             Object value = namesValues.nthValue(i);
             if (skipNullValues && (value == null)) {
                 continue;
             }
             if (needsSpace) {
                 logMessage.append(SPACE);
+            } else {
+                needsSpace = true;
             }
             formatSchemaName(logMessage, namesValues.nthName(i));
             logMessage.append('=');

--- a/maple-core/src/test/java/io/soabase/maple/TestGeneration.java
+++ b/maple-core/src/test/java/io/soabase/maple/TestGeneration.java
@@ -57,7 +57,6 @@ class TestGeneration {
     @Test
     void testInvalidSchema() {
         Stream.of(BadReturnType.class,
-                Duplicates.class,
                 InvalidMethod.class,
                 CannotBeAClass.class,
                 MustTake1ArgumentB.class,
@@ -108,6 +107,15 @@ class TestGeneration {
     void testMdcDefaultValue() {
         Names names = buildNames(HasMdcDefault.class);
         assertThat(names.nthSpecializations(0).contains(Specialization.DEFAULT_FROM_MDC)).isTrue();
+    }
+
+    @Test
+    void testDuplicates() {
+        Names names = buildNames(Duplicates.class);
+        assertThat(names.qty()).isEqualTo(2);
+        assertThat(names.nthName(0)).isEqualTo("id");
+        assertThat(names.nthName(1)).isEqualTo("id");
+        assertThat(names.nthRawName(0)).isNotEqualTo(names.nthRawName(1));
     }
 
     @Test

--- a/maple-core/src/test/java/io/soabase/maple/TestLogging.java
+++ b/maple-core/src/test/java/io/soabase/maple/TestLogging.java
@@ -106,11 +106,23 @@ class TestLogging {
     @Test
     void testInvalidSchema() {
         Stream.of(BadReturnType.class,
-                Duplicates.class,
                 InvalidMethod.class,
                 CannotBeAClass.class,
                 MustTake1ArgumentB.class,
                 MustReturnRightTypeInheritance.class
         ).forEach(clazz -> assertThatThrownBy(() -> MockMapleLogger.get(clazz)).isInstanceOf(InvalidSchemaException.class));
+    }
+
+    @Test
+    void testDuplicates() {
+        MockMapleLogger<Duplicates> logger = MockMapleLogger.get(Duplicates.class);
+        logger.info(s -> s.id("a string").id(101));
+        logger.debug(s -> s.id("s"));
+        logger.warn(s -> s.id(42));
+        assertThat(logger.logging()).containsSequence(
+                new LogEvent(LoggingLevel.INFO, "id=\"a string\" id=101", null),
+                new LogEvent(LoggingLevel.DEBUG, "id=s", null),
+                new LogEvent(LoggingLevel.WARN, "id=42", null)
+        );
     }
 }

--- a/maple-core/src/test/java/io/soabase/maple/schema/invalid/Duplicates.java
+++ b/maple-core/src/test/java/io/soabase/maple/schema/invalid/Duplicates.java
@@ -15,8 +15,12 @@
  */
 package io.soabase.maple.schema.invalid;
 
+import io.soabase.maple.api.annotations.SortOrder;
+
 public interface Duplicates {
+    @SortOrder(100)
     Duplicates id(int i);
 
+    @SortOrder(50)
     Duplicates id(String s);
 }


### PR DESCRIPTION
Relax restriction that a logging schema must contain unique names. The reason was due to an implementation detail that is easly overcome.