### PR TITLE
Fix Airlift and add logger names

### DIFF
--- a/maple-airlift/src/main/java/io/soabase/maple/airlift/AirliftLogger.java
+++ b/maple-airlift/src/main/java/io/soabase/maple/airlift/AirliftLogger.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2019 Jordan Zimmerman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.soabase.maple.airlift;
+
+import io.airlift.log.Logger;
+
+public class AirliftLogger {
+    private final Logger airliftLogger;
+    private final java.util.logging.Logger javaLogger;
+
+    public AirliftLogger(Logger airliftLogger, java.util.logging.Logger javaLogger) {
+        this.airliftLogger = airliftLogger;
+        this.javaLogger = javaLogger;
+    }
+
+    public void debug(Throwable exception, String message)
+    {
+        airliftLogger.debug(exception, message);
+    }
+
+    public void debug(String message)
+    {
+        airliftLogger.debug(message);
+    }
+
+    public void debug(String format, Object... args)
+    {
+        airliftLogger.debug(format, args);
+    }
+
+    public void debug(Throwable exception, String format, Object... args)
+    {
+        airliftLogger.debug(exception, format, args);
+    }
+
+    public void info(String message)
+    {
+        airliftLogger.info(message);
+    }
+
+    public void info(String format, Object... args)
+    {
+        airliftLogger.info(format, args);
+    }
+
+    public void warn(Throwable exception, String message)
+    {
+        airliftLogger.warn(exception, message);
+    }
+
+    public void warn(String message)
+    {
+        airliftLogger.warn(message);
+    }
+
+    public void warn(Throwable exception, String format, Object... args)
+    {
+        airliftLogger.warn(exception, format, args);
+    }
+
+    public void warn(String format, Object... args)
+    {
+        airliftLogger.warn(format, args);
+    }
+
+    public void error(Throwable exception, String message)
+    {
+        airliftLogger.error(exception, message);
+    }
+
+    public void error(String message)
+    {
+        airliftLogger.error(message);
+    }
+
+    public void error(Throwable exception, String format, Object... args)
+    {
+        airliftLogger.error(exception, format, args);
+    }
+
+    public void error(Throwable exception)
+    {
+        airliftLogger.error(exception);
+    }
+
+    public void error(String format, Object... args)
+    {
+        airliftLogger.error(format, args);
+    }
+
+    public boolean isDebugEnabled()
+    {
+        return airliftLogger.isDebugEnabled();
+    }
+
+    public boolean isInfoEnabled()
+    {
+        return airliftLogger.isInfoEnabled();
+    }
+
+    public java.util.logging.Logger getJavaLogger() {
+        return javaLogger;
+    }
+}

--- a/maple-airlift/src/main/java/io/soabase/maple/airlift/MapleFactory.java
+++ b/maple-airlift/src/main/java/io/soabase/maple/airlift/MapleFactory.java
@@ -33,7 +33,9 @@ public class MapleFactory {
      * @return {@link MapleLogger}
      */
     public static <T> MapleLogger<T> getLogger(String name, Class<T> schemaClass) {
-        return getLogger(Logger.get(name), schemaClass);
+        java.util.logging.Logger javaLogger = java.util.logging.Logger.getLogger(name);
+        Logger airliftLogger = Logger.get(name);
+        return getLogger(new AirliftLogger(airliftLogger, javaLogger), schemaClass);
     }
 
     /**
@@ -45,7 +47,7 @@ public class MapleFactory {
      * @return {@link MapleLogger}
      */
     public static <T> MapleLogger<T> getLogger(Class<?> clazz, Class<T> schemaClass) {
-        return getLogger(Logger.get(clazz), schemaClass);
+        return getLogger(clazz.getName(), schemaClass);
     }
 
     /**
@@ -55,7 +57,7 @@ public class MapleFactory {
      * @param schemaClass logging schema
      * @return {@link MapleLogger}
      */
-    public static <T> MapleLogger<T> getLogger(Logger logger, Class<T> schemaClass) {
+    public static <T> MapleLogger<T> getLogger(AirliftLogger logger, Class<T> schemaClass) {
         MetaInstance<T> metaInstance = MapleSpi.instance().generate(schemaClass);
         return new MapleLoggerImpl<>(metaInstance, logger);
     }

--- a/maple-airlift/src/main/java/io/soabase/maple/airlift/MapleLogger.java
+++ b/maple-airlift/src/main/java/io/soabase/maple/airlift/MapleLogger.java
@@ -15,7 +15,6 @@
  */
 package io.soabase.maple.airlift;
 
-import io.airlift.log.Logger;
 import io.soabase.maple.api.MapleLoggerApi;
 
 public interface MapleLogger<T> extends MapleLoggerApi<T> {
@@ -24,5 +23,5 @@ public interface MapleLogger<T> extends MapleLoggerApi<T> {
      *
      * @return airlift logger
      */
-    Logger logger();
+    AirliftLogger logger();
 }

--- a/maple-airlift/src/main/java/io/soabase/maple/airlift/MapleLoggerImpl.java
+++ b/maple-airlift/src/main/java/io/soabase/maple/airlift/MapleLoggerImpl.java
@@ -15,12 +15,11 @@
  */
 package io.soabase.maple.airlift;
 
-import io.airlift.log.Logger;
 import io.soabase.maple.core.StandardMapleLogger;
 import io.soabase.maple.spi.MetaInstance;
 
-class MapleLoggerImpl<T> extends StandardMapleLogger<T, Logger> implements MapleLogger<T> {
-    MapleLoggerImpl(MetaInstance<T> metaInstance, Logger logger) {
-        super(metaInstance, logger, Utils::isEnabled, Utils::levelLogger);
+class MapleLoggerImpl<T> extends StandardMapleLogger<T, AirliftLogger> implements MapleLogger<T> {
+    MapleLoggerImpl(MetaInstance<T> metaInstance, AirliftLogger logger) {
+        super(metaInstance, logger, Utils::isEnabledLoggerName, Utils::levelLogger);
     }
 }

--- a/maple-airlift/src/main/java/io/soabase/maple/airlift/Utils.java
+++ b/maple-airlift/src/main/java/io/soabase/maple/airlift/Utils.java
@@ -15,28 +15,29 @@
  */
 package io.soabase.maple.airlift;
 
-import io.airlift.log.Logger;
 import io.soabase.maple.api.LevelLogger;
 import io.soabase.maple.api.LoggingLevel;
 
+import java.util.logging.Level;
+
 class Utils {
-    static boolean isEnabled(LoggingLevel level, Logger logger) {
+    static String isEnabledLoggerName(LoggingLevel level, AirliftLogger logger) {
         switch (level) {
             case ERROR:
-                return true;    // Airlift doesn't currently support this
+                return logger.getJavaLogger().isLoggable(Level.SEVERE) ? logger.getJavaLogger().getName() : null;
             case WARN:
-                return true;    // Airlift doesn't currently support this
+                return logger.getJavaLogger().isLoggable(Level.WARNING) ? logger.getJavaLogger().getName() : null;
             case INFO:
-                return logger.isInfoEnabled();
+                return logger.isInfoEnabled() ? logger.getJavaLogger().getName() : null;
             case DEBUG:
-                return logger.isDebugEnabled();
+                return logger.isDebugEnabled() ? logger.getJavaLogger().getName() : null;
             case TRACE:
-                return false;
+                return null;
         }
         throw new IllegalStateException();  // should never get here
     }
 
-    static LevelLogger levelLogger(LoggingLevel level, Logger logger) {
+    static LevelLogger levelLogger(LoggingLevel level, AirliftLogger logger) {
         switch (level) {
             case ERROR:
                 return (msg, t) -> error(logger, msg, t);
@@ -53,7 +54,7 @@ class Utils {
         throw new IllegalStateException();  // should never get here
     }
 
-    private static void error(Logger logger, String msg, Throwable t) {
+    private static void error(AirliftLogger logger, String msg, Throwable t) {
         if (t != null) {
             logger.error(t, msg);
         } else {
@@ -61,7 +62,7 @@ class Utils {
         }
     }
 
-    private static void warn(Logger logger, String msg, Throwable t) {
+    private static void warn(AirliftLogger logger, String msg, Throwable t) {
         if (t != null) {
             logger.warn(t, msg);
         } else {
@@ -69,7 +70,7 @@ class Utils {
         }
     }
 
-    private static void info(Logger logger, String msg, Throwable t) {
+    private static void info(AirliftLogger logger, String msg, Throwable t) {
         if (t != null) {
             logger.info(msg + " %s", t);
         } else {
@@ -77,7 +78,7 @@ class Utils {
         }
     }
 
-    private static void debug(Logger logger, String msg, Throwable t) {
+    private static void debug(AirliftLogger logger, String msg, Throwable t) {
         if (t != null) {
             logger.debug(t, msg, t);
         } else {

--- a/maple-core/src/main/java/io/soabase/maple/api/MapleFormatter.java
+++ b/maple-core/src/main/java/io/soabase/maple/api/MapleFormatter.java
@@ -22,11 +22,11 @@ package io.soabase.maple.api;
 public interface MapleFormatter {
     /**
      * Apply generated name/value pairs and calling the underlying logger
-     *
-     * @param logger the logger proxy
+     *  @param logger the logger proxy
+     * @param loggerName
      * @param namesValues name/value pairs
      * @param mainMessage the main message to output or {@code ""}
      * @param t the exception to output or {@code null}
      */
-    void apply(LevelLogger logger, NamesValues namesValues, String mainMessage, Throwable t);
+    void apply(LevelLogger logger, String loggerName, NamesValues namesValues, String mainMessage, Throwable t);
 }

--- a/maple-core/src/main/java/io/soabase/maple/core/StandardMapleLogger.java
+++ b/maple-core/src/main/java/io/soabase/maple/core/StandardMapleLogger.java
@@ -20,21 +20,20 @@ import io.soabase.maple.spi.MapleSpi;
 import io.soabase.maple.spi.MetaInstance;
 
 import java.util.function.BiFunction;
-import java.util.function.BiPredicate;
 
 public class StandardMapleLogger<T, LOGGER> implements MapleLoggerBase<T> {
     private final MetaInstance<T> metaInstance;
     private final LOGGER logger;
     private final BiFunction<LoggingLevel, LOGGER, LevelLogger> levelLoggerProc;
-    private final BiPredicate<LoggingLevel, LOGGER> isEnabledProc;
+    private final BiFunction<LoggingLevel, LOGGER, String> isEnabledLoggerNameProc;
 
     public StandardMapleLogger(MetaInstance<T> metaInstance,
                                LOGGER logger,
-                               BiPredicate<LoggingLevel, LOGGER> isEnabledProc,
+                               BiFunction<LoggingLevel, LOGGER, String> isEnabledLoggerNameProc,
                                BiFunction<LoggingLevel, LOGGER, LevelLogger> levelLoggerProc) {
         this.metaInstance = metaInstance;
         this.logger = logger;
-        this.isEnabledProc = isEnabledProc;
+        this.isEnabledLoggerNameProc = isEnabledLoggerNameProc;
         this.levelLoggerProc = levelLoggerProc;
     }
 
@@ -44,8 +43,9 @@ public class StandardMapleLogger<T, LOGGER> implements MapleLoggerBase<T> {
 
     @Override
     public void consume(LoggingLevel loggingLevel, String mainMessage, Throwable t, Statement<T> statement) {
-        if (isEnabledProc.test(loggingLevel, logger)) {
-            MapleSpi.instance().consume(levelLoggerProc.apply(loggingLevel, logger), mainMessage, t, statement, metaInstance);
+        String loggerName = isEnabledLoggerNameProc.apply(loggingLevel, logger);
+        if (loggerName != null) {
+            MapleSpi.instance().consume(levelLoggerProc.apply(loggingLevel, logger), loggerName, mainMessage, t, statement, metaInstance);
         }
     }
 

--- a/maple-core/src/main/java/io/soabase/maple/formatters/ModelFormatter.java
+++ b/maple-core/src/main/java/io/soabase/maple/formatters/ModelFormatter.java
@@ -114,7 +114,7 @@ public class ModelFormatter implements MapleFormatter {
     }
 
     @Override
-    public void apply(LevelLogger logger, NamesValues namesValues, String mainMessage, Throwable t) {
+    public void apply(LevelLogger logger, String loggerName, NamesValues namesValues, String mainMessage, Throwable t) {
         List<String> appliedNames = new ArrayList<>();
         List<Object> appliedValues = new ArrayList<>();
         for (int i = 0; i < namesValues.qty(); ++i) {
@@ -154,7 +154,7 @@ public class ModelFormatter implements MapleFormatter {
                 return Stream.empty();
             }
         };
-        formatter.apply(logger, applied, mainMessage, t);
+        formatter.apply(logger, loggerName, applied, mainMessage, t);
     }
 
     private Handler getHandler(JsonNode node) {

--- a/maple-core/src/main/java/io/soabase/maple/formatters/StandardFormatter.java
+++ b/maple-core/src/main/java/io/soabase/maple/formatters/StandardFormatter.java
@@ -74,7 +74,7 @@ public class StandardFormatter implements MapleFormatter {
     }
 
     @Override
-    public void apply(LevelLogger logger, NamesValues namesValues, String mainMessage, Throwable t) {
+    public void apply(LevelLogger logger, String loggerName, NamesValues namesValues, String mainMessage, Throwable t) {
         StringBuilder logMessage = new StringBuilder(STRING_BUILDER_CAPACITY);
         boolean needsSpace = false;
         boolean hasMainMessage = !mainMessage.isEmpty();

--- a/maple-core/src/main/java/io/soabase/maple/spi/MapleSpi.java
+++ b/maple-core/src/main/java/io/soabase/maple/spi/MapleSpi.java
@@ -25,7 +25,7 @@ public interface MapleSpi {
         return Loaders.mapleSpiLoader.instance();
     }
 
-    <T> void consume(LevelLogger levelLogger, String mainMessage, Throwable t, Statement<T> statement, MetaInstance<T> metaInstance);
+    <T> void consume(LevelLogger levelLogger, String loggerName, String mainMessage, Throwable t, Statement<T> statement, MetaInstance<T> metaInstance);
 
     <T> MetaInstance<T> generate(Class<T> schemaClass);
 

--- a/maple-core/src/main/java/io/soabase/maple/spi/StandardMapleSpi.java
+++ b/maple-core/src/main/java/io/soabase/maple/spi/StandardMapleSpi.java
@@ -33,9 +33,9 @@ public class StandardMapleSpi implements MapleSpi {
     }
 
     @Override
-    public <T> void consume(LevelLogger levelLogger, String mainMessage, Throwable t, Statement<T> statement, MetaInstance<T> metaInstance) {
+    public <T> void consume(LevelLogger levelLogger, String loggerName, String mainMessage, Throwable t, Statement<T> statement, MetaInstance<T> metaInstance) {
         NamesValues namesValues = applySpecializations(statement.toNamesValues(metaInstance));
-        metaInstance.formatter().apply(levelLogger, namesValues, mainMessage, t);
+        metaInstance.formatter().apply(levelLogger, loggerName, namesValues, mainMessage, t);
     }
 
     @Override

--- a/maple-core/src/test/java/io/soabase/maple/MockMapleLogger.java
+++ b/maple-core/src/test/java/io/soabase/maple/MockMapleLogger.java
@@ -40,7 +40,7 @@ class MockMapleLogger<T> extends StandardMapleLogger<T, Object> {
     }
 
     private MockMapleLogger(MetaInstance<T> metaInstance, List<LogEvent> logging) {
-        super(metaInstance, new Object(), (level, o) -> true, (level, o) -> (msg, t) -> logging.add(new LogEvent(level, msg, t)));
+        super(metaInstance, new Object(), (level, o) -> "dummy", (level, o) -> (msg, t) -> logging.add(new LogEvent(level, msg, t)));
         this.logging = logging;
     }
 }

--- a/maple-core/src/test/java/io/soabase/maple/TestGeneration.java
+++ b/maple-core/src/test/java/io/soabase/maple/TestGeneration.java
@@ -157,7 +157,7 @@ class TestGeneration {
     void testCachingWithFormatters() {
         Names names = buildNames(BasicSchema.class);
 
-        MapleFormatter altFormatter = (logger, namesValues, mainMessage, t) -> {};
+        MapleFormatter altFormatter = (logger, loggerName, namesValues, mainMessage, t) -> {};
 
         MetaInstance<BasicSchema> metaInstance1 = generator.generate(names, BasicSchema.class, ClassLoader.getSystemClassLoader(), formatter);
         MetaInstance<BasicSchema> metaInstance2 = generator.generate(names, BasicSchema.class, ClassLoader.getSystemClassLoader(), altFormatter);

--- a/maple-slf4j/src/main/java/io/soabase/maple/slf4j/MapleLoggerImpl.java
+++ b/maple-slf4j/src/main/java/io/soabase/maple/slf4j/MapleLoggerImpl.java
@@ -21,6 +21,6 @@ import org.slf4j.Logger;
 
 class MapleLoggerImpl<T> extends StandardMapleLogger<T, Logger> implements MapleLogger<T> {
     MapleLoggerImpl(MetaInstance<T> metaInstance, Logger logger) {
-        super(metaInstance, logger, Utils::isEnabled, Utils::levelLogger);
+        super(metaInstance, logger, Utils::isEnabledLoggerName, Utils::levelLogger);
     }
 }

--- a/maple-slf4j/src/main/java/io/soabase/maple/slf4j/Utils.java
+++ b/maple-slf4j/src/main/java/io/soabase/maple/slf4j/Utils.java
@@ -20,18 +20,18 @@ import io.soabase.maple.api.LevelLogger;
 import org.slf4j.Logger;
 
 class Utils {
-    static boolean isEnabled(LoggingLevel level, Logger logger) {
+    static String isEnabledLoggerName(LoggingLevel level, Logger logger) {
         switch (level) {
             case ERROR:
-                return logger.isErrorEnabled();
+                return logger.isErrorEnabled() ? logger.getName() : null;
             case WARN:
-                return logger.isWarnEnabled();
+                return logger.isWarnEnabled() ? logger.getName() : null;
             case INFO:
-                return logger.isInfoEnabled();
+                return logger.isInfoEnabled() ? logger.getName() : null;
             case DEBUG:
-                return logger.isDebugEnabled();
+                return logger.isDebugEnabled() ? logger.getName() : null;
             case TRACE:
-                return logger.isTraceEnabled();
+                return logger.isTraceEnabled() ? logger.getName() : null;
         }
         throw new IllegalStateException();  // should never get here
     }


### PR DESCRIPTION
Airlift's API is too anemic. Instead use a Maple created "AirliftLogger"
that has Airlift's logger plus the Java logger that Airlift uses so as to
access extra features when needed.

Also, enhanced the formatter API to include the logger name.

NOTE: this is a breaking change to custom formatters