### PR TITLE
Use Schema's classloader

### DIFF
--- a/maple-core/src/main/java/io/soabase/maple/spi/StandardMapleSpi.java
+++ b/maple-core/src/main/java/io/soabase/maple/spi/StandardMapleSpi.java
@@ -29,7 +29,7 @@ public class StandardMapleSpi implements MapleSpi {
     @Override
     public <T> MetaInstance<T> generate(Class<T> schemaClass) {
         Names names = StandardNamesBuilder.build(schemaClass, Generator.getReservedMethodNames());
-        return generator.generate(names, schemaClass, ClassLoader.getSystemClassLoader(), formatter);
+        return generator.generate(names, schemaClass, schemaClass.getClassLoader(), formatter);
     }
 
     @Override


### PR DESCRIPTION
Maple was using the System ClassLoader for ByteBuddy. It turns out
this doesn't work well with some tools such as Maven. Instead, use
the ClassLoader of the schema class that is passed in.